### PR TITLE
feat: support registerInstance(serviceName, instance)

### DIFF
--- a/packages/nacos-config/package.json
+++ b/packages/nacos-config/package.json
@@ -30,7 +30,7 @@
     "mm": "^2.4.1",
     "pedding": "^1.1.0",
     "tslint": "^5.11.0",
-    "typescript": "^2.8.0"
+    "typescript": "^3.2.2"
   },
   "engines": {
     "node": ">= 8.0.0"

--- a/packages/nacos-naming/lib/naming/client.js
+++ b/packages/nacos-naming/lib/naming/client.js
@@ -57,13 +57,17 @@ class NacosNamingClient extends Base {
   }
 
   async registerInstance(serviceName, ip, port, clusterName = Constants.NAMING_DEFAULT_CLUSTER_NAME) {
-    const instance = new Instance({
-      ip,
-      port,
-      weight: 1,
-      clusterName,
-    });
-
+    let instance = null;
+    if (typeof ip === 'object') {
+      instance = new Instance(ip);
+    } else {
+      instance = new Instance({
+        ip,
+        port,
+        weight: 1,
+        clusterName,
+      });
+    }
     const beatInfo = {
       port,
       ip,

--- a/packages/nacos-naming/lib/naming/instance.js
+++ b/packages/nacos-naming/lib/naming/instance.js
@@ -17,6 +17,8 @@
 
 'use strict';
 
+const Constants = require('../const');
+
 class Instance {
   constructor(data = {}) {
     this.instanceId = data.instanceId; // Unique ID of this instance
@@ -31,7 +33,7 @@ class Instance {
       this.healthy = true;
     }
     this.enabled = typeof data.enabled === 'boolean' ? data.enabled : true;
-    this.clusterName = data.clusterName; // Cluster information of instance
+    this.clusterName = data.clusterName || Constants.NAMING_DEFAULT_CLUSTER_NAME; // Cluster information of instance
     this.serviceName = data.serviceName;
     this.metadata = data.metadata || {};
   }

--- a/packages/nacos-naming/lib/naming/push_receiver.js
+++ b/packages/nacos-naming/lib/naming/push_receiver.js
@@ -105,9 +105,6 @@ class PushReceiver extends Base {
 
   close() {
     this._isClosed = true;
-    if (this._server) {
-      this._server.close();
-    }
   }
 }
 

--- a/packages/nacos-naming/package.json
+++ b/packages/nacos-naming/package.json
@@ -44,7 +44,7 @@
     "address": "^1.0.3",
     "mz-modules": "^2.1.0",
     "sdk-base": "^3.5.1",
-    "urllib": "^2.31.2",
+    "urllib": "^2.33.0",
     "utility": "^1.15.0",
     "uuid": "^3.3.2"
   },
@@ -52,9 +52,9 @@
     "autod": "^3.0.1",
     "await-event": "^2.1.0",
     "contributors": "^0.5.1",
-    "egg-bin": "^4.9.0",
-    "egg-ci": "^1.10.0",
-    "eslint": "^5.9.0",
+    "egg-bin": "^4.10.0",
+    "egg-ci": "^1.11.0",
+    "eslint": "^5.12.0",
     "eslint-config-egg": "^7.1.0",
     "mm": "^2.4.1",
     "mz-modules": "^2.1.0"

--- a/packages/nacos-naming/test/naming/client.test.js
+++ b/packages/nacos-naming/test/naming/client.test.js
@@ -75,6 +75,25 @@ describe('test/naming/client.test.js', () => {
     client.unSubscribe(serviceName);
   });
 
+  it('should support registerInstance(serviceName, instance)', async function() {
+    const serviceName = 'nodejs.test.xxx.' + process.versions.node;
+    await client.registerInstance(serviceName, {
+      ip: '1.1.1.1',
+      port: 8888,
+      metadata: {
+        xxx: 'yyy',
+        foo: 'bar',
+      },
+    });
+    await sleep(2000);
+    const hosts = await client.getAllInstances(serviceName);
+    console.log(hosts);
+    const host = hosts.find(host => {
+      return host.ip === '1.1.1.1' && host.port === 8888;
+    });
+    assert.deepEqual(host.metadata, { foo: 'bar', xxx: 'yyy' });
+  });
+
   it('should getAllInstances ok', async function() {
     await client.registerInstance(serviceName, '1.1.1.1', 8080, 'NODEJS');
     await client.registerInstance(serviceName, '2.2.2.2', 8080, 'OTHERS');

--- a/packages/nacos-naming/test/naming/instance.test.js
+++ b/packages/nacos-naming/test/naming/instance.test.js
@@ -28,7 +28,7 @@ describe('test/naming/instance.test.js', () => {
       valid: true,
       enabled: false,
     });
-    assert(instance1.toString() === '{"ip":"1.1.1.1","port":8888,"weight":1,"healthy":true,"enabled":false,"metadata":{}}');
+    assert(instance1.toString() === '{"ip":"1.1.1.1","port":8888,"weight":1,"healthy":true,"enabled":false,"clusterName":"DEFAULT","metadata":{}}');
     assert(instance1.toInetAddr() === '1.1.1.1:8888');
 
     const instance2 = new Instance({
@@ -37,7 +37,7 @@ describe('test/naming/instance.test.js', () => {
       healthy: true,
       enabled: false,
     });
-    assert(instance2.toString() === '{"ip":"1.1.1.1","port":8888,"weight":1,"healthy":true,"enabled":false,"metadata":{}}');
+    assert(instance2.toString() === '{"ip":"1.1.1.1","port":8888,"weight":1,"healthy":true,"enabled":false,"clusterName":"DEFAULT","metadata":{}}');
     assert(instance2.toInetAddr() === '1.1.1.1:8888');
 
     assert(instance1.equal(instance2));
@@ -46,7 +46,7 @@ describe('test/naming/instance.test.js', () => {
       ip: '1.1.1.1',
       port: 8888,
     });
-    assert(instance3.toString() === '{"ip":"1.1.1.1","port":8888,"weight":1,"healthy":true,"enabled":true,"metadata":{}}');
+    assert(instance3.toString() === '{"ip":"1.1.1.1","port":8888,"weight":1,"healthy":true,"enabled":true,"clusterName":"DEFAULT","metadata":{}}');
     assert(instance3.toInetAddr() === '1.1.1.1:8888');
 
     assert(!instance1.equal(instance3));

--- a/packages/nacos/package.json
+++ b/packages/nacos/package.json
@@ -23,7 +23,7 @@
     "mm": "^2.4.1",
     "pedding": "^1.1.0",
     "tslint": "^5.11.0",
-    "typescript": "^2.8.0"
+    "typescript": "^3.2.2"
   },
   "engines": {
     "node": ">= 8.0.0"


### PR DESCRIPTION
```js
const serviceName = 'nodejs.test';
await client.registerInstance(serviceName, {
  ip: '1.1.1.1',
  port: 8888,
  metadata: {
     xxx: 'yyy',
     foo: 'bar',
  },
});
```