### PR TITLE
修改服务注册无法区分命名空间问题

### DIFF
--- a/packages/nacos-naming/example/client.js
+++ b/packages/nacos-naming/example/client.js
@@ -22,35 +22,36 @@ const sleep = require('mz-modules/sleep');
 const logger = console;
 
 async function test() {
-  const client = new NacosNamingClient({
-    logger,
-    serverList: '127.0.0.1:8848',
-  });
-  await client.ready();
+    const client = new NacosNamingClient({
+        logger,
+        serverList: '127.0.0.1:8848',
+        //namespace: '337ab180-1bfd-409b-9783-974f6c37f4' //namespaceId
+    });
+    await client.ready();
 
-  const serviceName = 'nodejs.test.nodejs.1';
+    const serviceName = 'nodejs.test.nodejs.1';
 
-  // console.log();
-  // console.log('before', await client.getAllInstances(serviceName, ['NODEJS']));
-  // console.log();
+    // console.log();
+    // console.log('before', await client.getAllInstances(serviceName, ['NODEJS']));
+    // console.log();
 
-  client.subscribe(serviceName, hosts => {
-    console.log(hosts);
-  });
+    client.subscribe(serviceName, hosts => {
+        console.log(hosts);
+    });
 
-  await client.registerInstance(serviceName, '1.1.1.1', 8080, 'NODEJS');
-  await client.registerInstance(serviceName, '2.2.2.2', 8080, 'NODEJS');
+    await client.registerInstance(serviceName, '1.1.1.1', 8080, 'NODEJS');
+    await client.registerInstance(serviceName, '2.2.2.2', 8080, 'NODEJS');
 
-  // const hosts = await client.getAllInstances(serviceName);
-  // console.log();
-  // console.log(hosts);
-  // console.log();
+    // const hosts = await client.getAllInstances(serviceName);
+    // console.log();
+    // console.log(hosts);
+    // console.log();
 
-  await sleep(5000);
+    await sleep(5000);
 
-  await client.deregisterInstance(serviceName, '1.1.1.1', 8080, 'NODEJS');
+    await client.deregisterInstance(serviceName, '1.1.1.1', 8080, 'NODEJS');
 }
 
 test().catch(err => {
-  console.log(err);
+    console.log(err);
 });

--- a/packages/nacos-naming/lib/naming/beat_reactor.js
+++ b/packages/nacos-naming/lib/naming/beat_reactor.js
@@ -23,74 +23,75 @@ const Constants = require('../const');
 const sleep = require('mz-modules/sleep');
 
 class BeatReactor extends Base {
-  constructor(options = {}) {
-    assert(options.logger, '[BeatReactor] options.logger is required');
-    assert(options.serverProxy, '[BeatReactor] options.serverProxy is required');
-    super(options);
+    constructor(options = {}) {
+        assert(options.logger, '[BeatReactor] options.logger is required');
+        assert(options.serverProxy, '[BeatReactor] options.serverProxy is required');
+        super(options);
 
-    this._isClosed = false;
-    this._dom2Beat = new Map();
-    this._isRunning = false;
-    this._clientBeatInterval = 10 * 1000;
-    this._startBeat();
-    this.ready(true);
-  }
-
-  get logger() {
-    return this.options.logger;
-  }
-
-  get serverProxy() {
-    return this.options.serverProxy;
-  }
-
-  addBeatInfo(serviceName, beatInfo) {
-    this._dom2Beat.set(this._buildKey(serviceName, beatInfo.ip, beatInfo.port), beatInfo);
-  }
-
-  removeBeatInfo(serviceName, ip, port) {
-    this._dom2Beat.delete(this._buildKey(serviceName, ip, port));
-  }
-
-  _buildKey(dom, ip, port) {
-    return dom + Constants.NAMING_INSTANCE_ID_SPLITTER + ip + Constants.NAMING_INSTANCE_ID_SPLITTER + port;
-  }
-
-  async _beat(beatInfo) {
-    const params = {
-      beat: JSON.stringify(beatInfo),
-      dom: beatInfo.dom,
-    };
-    try {
-      const result = await this.serverProxy.reqAPI(Constants.NACOS_URL_BASE + '/api/clientBeat', params);
-      const jsonObject = JSON.parse(result);
-      if (jsonObject) {
-        this._clientBeatInterval = jsonObject.clientBeatInterval;
-      }
-    } catch (err) {
-      err.message = '[CLIENT-BEAT] failed to send beat: ' + JSON.stringify(beatInfo) + ', caused by ' + err.message;
-      this.emit('error', err);
+        this._isClosed = false;
+        this._dom2Beat = new Map();
+        this._isRunning = false;
+        this._clientBeatInterval = 10 * 1000;
+        this._startBeat();
+        this.ready(true);
     }
-  }
 
-  async _startBeat() {
-    if (this._isRunning) return;
-
-    this._isRunning = true;
-    while (!this._isClosed) {
-      for (const beatInfo of this._dom2Beat.values()) {
-        this._beat(beatInfo);
-      }
-      await sleep(this._clientBeatInterval);
+    get logger() {
+        return this.options.logger;
     }
-    this._isRunning = false;
-  }
 
-  close() {
-    this._isClosed = true;
-    this._isRunning = false;
-    this._dom2Beat.clear();
-  }
+    get serverProxy() {
+        return this.options.serverProxy;
+    }
+
+    addBeatInfo(serviceName, beatInfo) {
+        this._dom2Beat.set(this._buildKey(serviceName, beatInfo.ip, beatInfo.port), beatInfo);
+    }
+
+    removeBeatInfo(serviceName, ip, port) {
+        this._dom2Beat.delete(this._buildKey(serviceName, ip, port));
+    }
+
+    _buildKey(dom, ip, port) {
+        return dom + Constants.NAMING_INSTANCE_ID_SPLITTER + ip + Constants.NAMING_INSTANCE_ID_SPLITTER + port;
+    }
+
+    async _beat(beatInfo) {
+        const params = {
+            namespaceId: beatInfo.namespace,
+            beat: JSON.stringify(beatInfo),
+            dom: beatInfo.dom,
+        };
+        try {
+            const result = await this.serverProxy.reqAPI(Constants.NACOS_URL_BASE + '/api/clientBeat', params);
+            const jsonObject = JSON.parse(result);
+            if (jsonObject) {
+                this._clientBeatInterval = jsonObject.clientBeatInterval;
+            }
+        } catch (err) {
+            err.message = '[CLIENT-BEAT] failed to send beat: ' + JSON.stringify(beatInfo) + ', caused by ' + err.message;
+            this.emit('error', err);
+        }
+    }
+
+    async _startBeat() {
+        if (this._isRunning) return;
+
+        this._isRunning = true;
+        while (!this._isClosed) {
+            for (const beatInfo of this._dom2Beat.values()) {
+                this._beat(beatInfo);
+            }
+            await sleep(this._clientBeatInterval);
+        }
+        this._isRunning = false;
+    }
+
+    close() {
+        this._isClosed = true;
+        this._isRunning = false;
+        this._dom2Beat.clear();
+    }
 }
 
 module.exports = BeatReactor;

--- a/packages/nacos-naming/lib/naming/proxy.js
+++ b/packages/nacos-naming/lib/naming/proxy.js
@@ -24,141 +24,141 @@ const utility = require('utility');
 const Constants = require('../const');
 
 const defaultOptions = {
-  namespace: 'default',
-  httpclient: require('urllib'),
-  ssl: false,
+    namespace: 'default',
+    httpclient: require('urllib'),
+    ssl: false,
 };
 const DEFAULT_SERVER_PORT = 8848;
 
 class NameProxy extends Base {
-  constructor(options = {}) {
-    assert(options.logger, '[NameProxy] options.logger is required');
-    if (typeof options.serverList === 'string' && options.serverList) {
-      options.serverList = options.serverList.split(',');
-    }
-    super(Object.assign({}, defaultOptions, options));
-    // 硬负载域名
-    if (options.serverList.length === 1) {
-      this.nacosDomain = options.serverList[0];
-    }
-    this.serverList = options.serverList || [];
-    this.ready(true);
-  }
-
-  get logger() {
-    return this.options.logger;
-  }
-
-  get namespace() {
-    return this.options.namespace;
-  }
-
-  get httpclient() {
-    return this.options.httpclient;
-  }
-
-  async _callServer(serverAddr, method, api, params) {
-    const headers = {
-      'Client-Version': Constants.VERSION,
-      'Accept-Encoding': 'gzip,deflate,sdch',
-      Connection: 'Keep-Alive',
-      RequestId: uuid(),
-      'User-Agent': 'Nacos-Java-Client',
-    };
-
-    if (!serverAddr.includes(Constants.SERVER_ADDR_IP_SPLITER)) {
-      serverAddr = serverAddr + Constants.SERVER_ADDR_IP_SPLITER + DEFAULT_SERVER_PORT;
-    }
-
-    const url = (this.options.ssl ? 'https://' : 'http://') + serverAddr + api;
-    const result = await this.httpclient.request(url, {
-      method,
-      headers,
-      data: params,
-      dataType: 'text',
-      dataAsQueryString: true,
-    });
-
-    if (result.status === 200) {
-      return result.data;
-    }
-    if (result.status === 304) {
-      return '';
-    }
-    const err = new Error('failed to req API: ' + url + '. code: ' + result.status + ' msg: ' + result.data);
-    err.name = 'NacosException';
-    throw err;
-  }
-
-  async reqAPI(api, params, method) {
-    // TODO:
-    const servers = this.serverList;
-    const size = servers.length;
-
-    if (size === 0 && !this.nacosDomain) {
-      throw new Error('[NameProxy] no server available');
-    }
-
-    if (size > 0) {
-      let index = utility.random(size);
-      for (let i = 0; i < size; i++) {
-        const server = servers[index];
-        try {
-          return await this._callServer(server, method, api, params);
-        } catch (err) {
-          this.logger.warn(err);
+    constructor(options = {}) {
+        assert(options.logger, '[NameProxy] options.logger is required');
+        if (typeof options.serverList === 'string' && options.serverList) {
+            options.serverList = options.serverList.split(',');
         }
-        index = (index + 1) % size;
-      }
-      throw new Error('failed to req API: ' + api + ' after all servers(' + servers.join(',') + ') tried');
+        super(Object.assign({}, defaultOptions, options));
+        // 硬负载域名
+        if (options.serverList.length === 1) {
+            this.nacosDomain = options.serverList[0];
+        }
+        this.serverList = options.serverList || [];
+        this.ready(true);
     }
 
-    for (let i = 0; i < Constants.REQUEST_DOMAIN_RETRY_COUNT; i++) {
-      try {
-        return await this._callServer(this.nacosDomain, method, api, params);
-      } catch (err) {
-        this.logger.warn(err);
-      }
+    get logger() {
+        return this.options.logger;
     }
-    throw new Error('failed to req API: ' + api + ' after all servers(' + this.nacosDomain + ') tried');
-  }
 
-  async registerService(serviceName, instance) {
-    this.logger.info('[NameProxy][REGISTER-SERVICE] registering service: %s with instance:%j', serviceName, instance);
-
-    const params = {
-      tenant: this.namespace,
-      ip: instance.ip,
-      port: instance.port + '',
-      weight: instance.weight + '',
-      enable: instance.enabled ? 'true' : 'false',
-      healthy: instance.healthy ? 'true' : 'false',
-      metadata: JSON.stringify(instance.metadata),
-      clusterName: instance.clusterName,
-      serviceName,
-    };
-    return await this.reqAPI(Constants.NACOS_URL_INSTANCE, params, 'PUT');
-  }
-
-  async deregisterService(serviceName, ip, port, cluster) {
-    const params = {
-      tenant: this.namespace,
-      ip,
-      port: port + '',
-      serviceName,
-      cluster,
-    };
-    return await this.reqAPI(Constants.NACOS_URL_INSTANCE, params, 'DELETE');
-  }
-
-  async serverHealthy() {
-    try {
-      await this.reqAPI(Constants.NACOS_URL_BASE + '/api/hello', {}, 'GET');
-    } catch (_) {
-      return false;
+    get namespace() {
+        return this.options.namespace;
     }
-    return true;
-  }
+
+    get httpclient() {
+        return this.options.httpclient;
+    }
+
+    async _callServer(serverAddr, method, api, params) {
+        const headers = {
+            'Client-Version': Constants.VERSION,
+            'Accept-Encoding': 'gzip,deflate,sdch',
+            Connection: 'Keep-Alive',
+            RequestId: uuid(),
+            'User-Agent': 'Nacos-Java-Client',
+        };
+
+        if (!serverAddr.includes(Constants.SERVER_ADDR_IP_SPLITER)) {
+            serverAddr = serverAddr + Constants.SERVER_ADDR_IP_SPLITER + DEFAULT_SERVER_PORT;
+        }
+
+        const url = (this.options.ssl ? 'https://' : 'http://') + serverAddr + api;
+        const result = await this.httpclient.request(url, {
+            method,
+            headers,
+            data: params,
+            dataType: 'text',
+            dataAsQueryString: true,
+        });
+
+        if (result.status === 200) {
+            return result.data;
+        }
+        if (result.status === 304) {
+            return '';
+        }
+        const err = new Error('failed to req API: ' + url + '. code: ' + result.status + ' msg: ' + result.data);
+        err.name = 'NacosException';
+        throw err;
+    }
+
+    async reqAPI(api, params, method) {
+        // TODO:
+        const servers = this.serverList;
+        const size = servers.length;
+
+        if (size === 0 && !this.nacosDomain) {
+            throw new Error('[NameProxy] no server available');
+        }
+
+        if (size > 0) {
+            let index = utility.random(size);
+            for (let i = 0; i < size; i++) {
+                const server = servers[index];
+                try {
+                    return await this._callServer(server, method, api, params);
+                } catch (err) {
+                    this.logger.warn(err);
+                }
+                index = (index + 1) % size;
+            }
+            throw new Error('failed to req API: ' + api + ' after all servers(' + servers.join(',') + ') tried');
+        }
+
+        for (let i = 0; i < Constants.REQUEST_DOMAIN_RETRY_COUNT; i++) {
+            try {
+                return await this._callServer(this.nacosDomain, method, api, params);
+            } catch (err) {
+                this.logger.warn(err);
+            }
+        }
+        throw new Error('failed to req API: ' + api + ' after all servers(' + this.nacosDomain + ') tried');
+    }
+
+    async registerService(serviceName, instance) {
+        this.logger.info('[NameProxy][REGISTER-SERVICE] registering service: %s with instance:%j', serviceName, instance);
+
+        const params = {
+            namespaceId: this.namespace,
+            ip: instance.ip,
+            port: instance.port + '',
+            weight: instance.weight + '',
+            enable: instance.enabled ? 'true' : 'false',
+            healthy: instance.healthy ? 'true' : 'false',
+            metadata: JSON.stringify(instance.metadata),
+            clusterName: instance.clusterName,
+            serviceName,
+        };
+        return await this.reqAPI(Constants.NACOS_URL_INSTANCE, params, 'PUT');
+    }
+
+    async deregisterService(serviceName, ip, port, cluster) {
+        const params = {
+            namespaceId: this.namespace,
+            ip,
+            port: port + '',
+            serviceName,
+            cluster,
+        };
+        return await this.reqAPI(Constants.NACOS_URL_INSTANCE, params, 'DELETE');
+    }
+
+    async serverHealthy() {
+        try {
+            await this.reqAPI(Constants.NACOS_URL_BASE + '/api/hello', {}, 'GET');
+        } catch (_) {
+            return false;
+        }
+        return true;
+    }
 }
 
 module.exports = NameProxy;


### PR DESCRIPTION
只增加部分namespace提交参数，在1.0.0实践中能够使服务在不通命名空间中常驻。解决了之前服务心跳中断的问题。尚不知是否符合广泛要求。