### PR TITLE
feat: support new authentication mode

### DIFF
--- a/packages/nacos-config/src/http_agent.ts
+++ b/packages/nacos-config/src/http_agent.ts
@@ -107,6 +107,11 @@ export class HttpAgent {
     const endTime = Date.now() + timeout;
     let lastErr;
 
+    if (this.options.configuration.innerConfig.username &&
+        this.options.configuration.innerConfig.password) {
+      data.username = this.options.configuration.innerConfig.username;
+      data.password = this.options.configuration.innerConfig.password;
+    }
     let signStr = data.tenant;
     if (data.group && data.tenant) {
       signStr = data.tenant + '+' + data.group;

--- a/packages/nacos-naming/lib/naming/proxy.js
+++ b/packages/nacos-naming/lib/naming/proxy.js
@@ -160,6 +160,10 @@ class NameProxy extends Base {
     }
 
     const url = (this.options.ssl ? 'https://' : 'http://') + serverAddr + api;
+    if (this.options.username && this.options.password) {
+      params.username = this.options.username;
+      params.password = this.options.password;
+    }
     const result = await this.httpclient.request(url, {
       method,
       headers,


### PR DESCRIPTION
### If turn on auth system:
nacos.core.auth.enabled=true
认证模式开启添加认证参数
const client = new NacosNamingClient({
  logger,
  serverList: '127.0.0.1:8848', // replace to real nacos serverList
  namespace: 'public',
  username: 'user',
  password: 'pass'
});

const configClient = new NacosConfigClient({
  serverAddr: '127.0.0.1:8848',
  username: 'user',
  password: 'pass'
});