### PR TITLE
fix: fix the request address is undefined after SSL is enabled

### DIFF
--- a/packages/nacos-config/src/http_agent.ts
+++ b/packages/nacos-config/src/http_agent.ts
@@ -23,7 +23,6 @@ import { encodingParams, transformGBKToUTF8 } from './utils';
 export class HttpAgent {
 
   options;
-  currentServer: string;
   protected loggerDomain = 'Nacos';
   private debugPrefix = this.loggerDomain.toLowerCase();
   private debug = require('debug')(`${this.debugPrefix}:${process.pid}:http_agent`);
@@ -188,12 +187,12 @@ export class HttpAgent {
     if (/:/.test(currentServer)) {
       url = `http://${currentServer}`;
       if (this.ssl) {
-        url = `https://${this.currentServer}`;
+        url = `https://${currentServer}`;
       }
     } else {
       url = `http://${currentServer}:${this.serverPort}`;
       if (this.ssl) {
-        url = `https://${this.currentServer}:${this.serverPort}`;
+        url = `https://${currentServer}:${this.serverPort}`;
       }
     }
     return `${url}/${this.contextPath}`;


### PR DESCRIPTION
当ssl为true时，请求服务地址的host和port会变成undefined，查看源码发现在http_agent.ts在调用getRequestUrl时判断ssl为true后使用了未赋值的属性引起的。