### PR TITLE
Fix deregisterInstance with groupName

### DIFF
--- a/packages/nacos-naming/lib/naming/client.js
+++ b/packages/nacos-naming/lib/naming/client.js
@@ -80,7 +80,7 @@ class NacosNamingClient extends Base {
     }
     const serviceNameWithGroup = utils.getGroupedName(serviceName, groupName);
     this._beatReactor.removeBeatInfo(serviceNameWithGroup, instance.ip, instance.port);
-    await this._serverProxy.deregisterService(serviceName, instance);
+    await this._serverProxy.deregisterService(serviceNameWithGroup, instance);
   }
 
   async getAllInstances(serviceName, groupName = Constants.DEFAULT_GROUP, clusters = '', subscribe = true) {


### PR DESCRIPTION
修复deregisterInstance  groupName 参数未起效，代码错误