### PR TITLE
feat: support custom httpAgent

### DIFF
--- a/packages/nacos-config/src/client.ts
+++ b/packages/nacos-config/src/client.ts
@@ -54,7 +54,8 @@ export class DataClient extends Base implements BaseClient {
 
     this.snapshot = this.getSnapshot();
     this.serverMgr = this.getServerListManager();
-    this.httpAgent = new HttpAgent({ configuration: this.configuration });
+    const CustomHttpAgent = this.configuration.get(ClientOptionKeys.HTTP_AGENT);
+    this.httpAgent = CustomHttpAgent ? new CustomHttpAgent({ configuration: this.configuration }) : new HttpAgent({ configuration: this.configuration });
 
     this.configuration.merge({
       snapshot: this.snapshot,

--- a/packages/nacos-config/src/index.ts
+++ b/packages/nacos-config/src/index.ts
@@ -24,6 +24,7 @@ export { DataClient } from './client';
 export { ClientWorker } from './client_worker';
 export { ServerListManager } from './server_list_mgr';
 export { Snapshot } from './snapshot';
+export { HttpAgent } from './http_agent'
 
 const APIClientBase = require('cluster-client').APIClientBase;
 

--- a/packages/nacos-config/src/interface.ts
+++ b/packages/nacos-config/src/interface.ts
@@ -251,6 +251,7 @@ export interface ClientOptions {
   accessKey?: string;         // 阿里云的 accessKey
   secretKey?: string;         // 阿里云的 secretKey
   httpclient?: any;           // http 请求客户端，默认为 urllib
+  httpAgent?: any;            // httpAgent
   appName?: string;           // 应用名，可选
   ssl?: boolean;              // 是否为 https 请求
   refreshInterval?: number;   // 重新拉去地址列表的间隔时间

--- a/packages/nacos-config/test/client.test.ts
+++ b/packages/nacos-config/test/client.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import { DataClient } from '../src/client';
+import { HttpAgent } from '../src/http_agent'
 
 const mm = require('mm');
 const assert = require('assert');
@@ -115,6 +116,22 @@ describe('test/client.test.ts', () => {
         assert(err.message.indexOf('only allow digital, letter and symbols in [ "_", "-", ".", ":" ]') > -1);
       }
     });
+  });
+
+  it('support custom httpAgent', () => {
+    class CustomHttpAgent {};
+    assert(client.httpAgent instanceof HttpAgent);
+    client = new DataClient({
+      appName: 'test',
+      endpoint: 'acm.aliyun.com',
+      namespace: '81597370-5076-4216-9df5-538a2b55bac3',
+      accessKey: '4c796a4dcd0d4f5895d4ba83a296b489',
+      secretKey: 'UjLemP8inirhjMg1NZyY0faOk1E=',
+      httpclient,
+      httpAgent: CustomHttpAgent,
+      ssl: false
+    });
+    assert(client.httpAgent instanceof CustomHttpAgent);
   });
 
 });


### PR DESCRIPTION
> java 参考 https://github.com/alibaba/nacos/blob/32b20c906f16e09b2512aeb279a5da2b410f5b60/client/src/main/java/com/alibaba/nacos/client/config/NacosConfigService.java#L168

---
### 背景
nacos 配置服务增加了加密新特性，密钥 key 通过 resonse header 传递，所以客户端需要 http_agent 可自定义处理加密数据

### 修改
客户端增加 httpAgent 配置参数，如果有传入优先使用自定义 httpAgent，没有则使用默认 httpAgent
