### PR TITLE
feat: support custom decode res data

### DIFF
--- a/packages/nacos-config/src/http_agent.ts
+++ b/packages/nacos-config/src/http_agent.ts
@@ -90,6 +90,10 @@ export class HttpAgent {
     return this.configuration.get(ClientOptionKeys.IDENTITY_VALUE);
   }
 
+  get decodeRes() {
+    return this.configuration.get(ClientOptionKeys.DECODE_RES);
+  }
+
 
   /**
    * 请求
@@ -166,6 +170,9 @@ export class HttpAgent {
         this.debug('%s %s, got %s, body: %j', method, url, res.status, res.data);
         switch (res.status) {
           case HTTP_OK:
+            if (this.decodeRes) {
+              return this.decodeRes(res, method, this.defaultEncoding)
+            }
             return this.decodeResData(res, method);
           case HTTP_NOT_FOUND:
             return null;

--- a/packages/nacos-config/src/interface.ts
+++ b/packages/nacos-config/src/interface.ts
@@ -265,6 +265,7 @@ export interface ClientOptions {
   cacheDir?: string;          // 缓存文件的路径
   identityKey?: string;       // Identity Key
   identityValue?: string;     // Identity Value
+  decodeRes?: (res: any, method?: string, encoding?: string) => any
 }
 
 export enum ClientOptionKeys {
@@ -290,6 +291,7 @@ export enum ClientOptionKeys {
   DEFAULT_ENCODING = 'defaultEncoding',
   IDENTITY_KEY = 'identityKey',
   IDENTITY_VALUE = 'identityValue',
+  DECODE_RES = 'decodeRes',
 }
 
 export interface IConfiguration {

--- a/packages/nacos-config/test/utils.ts
+++ b/packages/nacos-config/test/utils.ts
@@ -18,14 +18,6 @@
 import { Configuration } from '../src/configuration';
 import { DEFAULT_OPTIONS } from '../src/const';
 
-export function delay(timeout) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve();
-    }, timeout);
-  });
-}
-
 export function createDefaultConfiguration(config: any) {
   return new Configuration(Object.assign({}, DEFAULT_OPTIONS)).merge(config);
 }


### PR DESCRIPTION
### 背景
nacos 配置服务增加了加密新特性，密钥 key 通过 resonse header 传递，之前让用户自定义 `http_agent` 太重，提供轻便的钩子方法即可处理

### 修改
新增 `decodeRes` 配置项，用户传入 `decodeRes` 则使用用户的方法处理返回结果，不传入则保持原来的处理方式