### PR TITLE
fix: ignore empty hosts array

### DIFF
--- a/packages/nacos-naming/lib/naming/service_info.js
+++ b/packages/nacos-naming/lib/naming/service_info.js
@@ -40,7 +40,12 @@ class ServiceInfo {
   }
 
   get isValid() {
-    return !!this.hosts;
+    const valid = !!this.hosts;
+    // 如果 this.hosts 是空数组要返回 false
+    if (valid && Array.isArray(this.hosts)) {
+      return this.hosts.length > 0;
+    }
+    return valid;
   }
 
   getKey() {


### PR DESCRIPTION
**背景**
Nacos 注册中心变更（扩容/重启/上下线）都会出现注册服务数据不一致的短暂过程，而变更过程中，可能出现 0 的提供者的数据情况，所以会让消费者客户端出现 no provider 异常；Java 应用均支持并开启了防推空，Node 客户端没有判断空数组的情况，需要修复客户端判断逻辑。
> Java 客户端参考 https://github.com/alibaba/nacos/blob/v1.X/api/src/main/java/com/alibaba/nacos/api/naming/pojo/ServiceInfo.java#L165-L186

**修改**
isValid 属性判断增加空数组判断