### PR TITLE
fix: comparing the host information using an unstable JSON string

### DIFF
--- a/packages/nacos-naming/lib/naming/host_reactor.js
+++ b/packages/nacos-naming/lib/naming/host_reactor.js
@@ -22,6 +22,7 @@ const Base = require('sdk-base');
 const Constants = require('../const');
 const ServiceInfo = require('./service_info');
 const PushReceiver = require('./push_receiver');
+const equals = require('equals');
 
 class HostReactor extends Base {
   constructor(options = {}) {
@@ -92,7 +93,7 @@ class HostReactor extends Base {
         const key = host.ip + ':' + host.port;
         newHostMap.set(key, host);
 
-        if (oldHostMap.has(key) && JSON.stringify(host) !== JSON.stringify(oldHostMap.get(key))) {
+        if (oldHostMap.has(key) && !equals(host, oldHostMap.get(key))) {
           modHosts.push(host);
           continue;
         }

--- a/packages/nacos-naming/package.json
+++ b/packages/nacos-naming/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "address": "^1.1.0",
+    "equals": "^1.0.5",
     "mz-modules": "^2.1.0",
     "sdk-base": "^3.6.0",
     "urllib": "^2.33.3",


### PR DESCRIPTION
when using nacos-sdk-nodejs with nacos server 2.x version, server response host info field order is unstable, compare Object with JSON string is the wrong way. 