### PR TITLE
a type error for Hosts

### DIFF
--- a/packages/nacos-naming/index.d.ts
+++ b/packages/nacos-naming/index.d.ts
@@ -10,7 +10,24 @@ interface Instance {
   clusterName?: string
 }
 
-type Hosts = string[];
+export interface Host {
+  instanceId: string;
+  ip: string;
+  port: number;
+  weight: number;
+  healthy: boolean;
+  enabled: boolean;
+  ephemeral: boolean;
+  clusterName: string;
+  serviceName: string;
+  metadata: any;
+  instanceHeartBeatInterval: number;
+  instanceIdGenerator: string;
+  instanceHeartBeatTimeOut: number;
+  ipDeleteTimeout: number;
+}
+
+type Hosts = Host[];
 
 interface SubscribeInfo {
   serviceName: string,


### PR DESCRIPTION
I have deployed NACOS version 2.1.1. Has the type changed here because of the version upgrade? I have fixed it
The actual return result is as follows:
`[
  {
    instanceId: '127.0.0.1#3000#DEFAULT#DEFAULT_GROUP@@test',
    ip: '127.0.0.1',
    port: 3000,
    weight: 1,
    healthy: true,
    enabled: true,
    ephemeral: true,
    clusterName: 'DEFAULT',
    serviceName: 'DEFAULT_GROUP@@test',
    metadata: {},
    instanceHeartBeatInterval: 5000,
    instanceIdGenerator: 'simple',
    instanceHeartBeatTimeOut: 15000,
    ipDeleteTimeout: 30000
  }
]`