### PR TITLE
docs(nacos-config): For#67, mark batch and aggregate APIs as deprecated.

### DIFF
--- a/packages/nacos-config/src/client.ts
+++ b/packages/nacos-config/src/client.ts
@@ -181,6 +181,9 @@ export class DataClient extends Base implements BaseClient {
   }
 
   /**
+   * @deprecated This API is not implemented and will be removed in a future version.
+   * Nacos server does not support batch configuration retrieval operations.
+   * Please use individual getConfig() calls instead.
    * 批量获取配置
    * @param {Array} dataIds - data id array
    * @param {String} group - group name of the data
@@ -195,6 +198,9 @@ export class DataClient extends Base implements BaseClient {
   }
 
   /**
+   * @deprecated This API is not implemented and will be removed in a future version.
+   * Nacos server does not support batch query operations.
+   * Please use individual query methods instead.
    * 批量查询
    * @param {Array} dataIds - data id array
    * @param {String} group - group name of the data
@@ -235,12 +241,18 @@ export class DataClient extends Base implements BaseClient {
     return true;
   }
 
+  /**
+   * @deprecated This API is not implemented and will be removed in a future version
+   */
   async publishAggr(dataId, group, datumId, content, options) {
     checkParameters(dataId, group, datumId);
     const client = this.getClient(options);
     return await client.publishAggr(dataId, group, datumId, content);
   }
 
+  /**
+   * @deprecated This API is not implemented and will be removed in a future version
+   */
   async removeAggr(dataId, group, datumId, options) {
     checkParameters(dataId, group, datumId);
     const client = this.getClient(options);

--- a/packages/nacos-config/src/client_worker.ts
+++ b/packages/nacos-config/src/client_worker.ts
@@ -387,15 +387,24 @@ export class ClientWorker extends Base implements IClientWorker {
     return true;
   }
 
+  /**
+   * @deprecated This API is not implemented and will be removed in a future version
+   */
   async publishAggr(dataId, group, datumId, content) {
     return true;
   }
 
+  /**
+   * @deprecated This API is not implemented and will be removed in a future version
+   */
   async removeAggr(dataId, group, datumId) {
     return null;
   }
 
   /**
+   * @deprecated This API is not implemented and will be removed in a future version.
+   * Nacos server does not support batch configuration retrieval operations.
+   * Please use individual getConfig() calls instead.
    * 批量获取配置
    * @param {Array} dataIds - data id array
    * @param {String} group - group name of the data
@@ -406,6 +415,9 @@ export class ClientWorker extends Base implements IClientWorker {
   }
 
   /**
+   * @deprecated This API is not implemented and will be removed in a future version.
+   * Nacos server does not support batch query operations.
+   * Please use individual query methods instead.
    * 批量查询
    * @param {Array} dataIds - data id array
    * @param {String} group - group name of the data

--- a/packages/nacos-config/src/index.ts
+++ b/packages/nacos-config/src/index.ts
@@ -148,6 +148,9 @@ export class NacosConfigClient extends APIClientBase implements BaseClient {
   }
 
   /**
+   * @deprecated This API is not implemented and will be removed in a future version.
+   * Nacos server does not support batch configuration retrieval operations.
+   * Please use individual getConfig() calls instead.
    * 批量获取配置
    * @param {Array} dataIds - data id array
    * @param {String} group - group name of the data
@@ -161,6 +164,9 @@ export class NacosConfigClient extends APIClientBase implements BaseClient {
   }
 
   /**
+   * @deprecated This API is not implemented and will be removed in a future version.
+   * Nacos server does not support batch query operations.
+   * Please use individual query methods instead.
    * 批量查询
    * @param {Array} dataIds - data id array
    * @param {String} group - group name of the data
@@ -196,11 +202,17 @@ export class NacosConfigClient extends APIClientBase implements BaseClient {
     return await this._client.removeToAllUnit(dataId, group);
   }
 
+  /**
+   * @deprecated This API is not implemented and will be removed in a future version
+   */
   async publishAggr(dataId, group, datumId, content, options) {
     checkParameters(dataId, group, datumId);
     return await this._client.publishAggr(dataId, group, datumId, content, options);
   }
 
+  /**
+   * @deprecated This API is not implemented and will be removed in a future version
+   */
   async removeAggr(dataId, group, datumId, options) {
     checkParameters(dataId, group, datumId);
     return await this._client.removeAggr(dataId, group, datumId, options);

--- a/packages/nacos-config/src/interface.ts
+++ b/packages/nacos-config/src/interface.ts
@@ -119,6 +119,7 @@ export interface IClientWorker {
    * @param {Object} [options]
    *  - {String} unit
    * @returns {Promise<boolean>} true | false
+   * @deprecated This API is not implemented and will be removed in a future version
    */
   publishAggr(dataId: string, group: string, datumId: string, content: string, options?: UnitOptions): Promise<boolean>;
 
@@ -130,6 +131,7 @@ export interface IClientWorker {
    * @param {Object} [options]
    *  - {String} unit
    * @returns {Promise<boolean>} true | false
+   * @deprecated This API is not implemented and will be removed in a future version
    */
   removeAggr(dataId: string, group: string, datumId: string, options?: UnitOptions): Promise<boolean>;
 
@@ -140,6 +142,9 @@ export interface IClientWorker {
    * @param {Object} [options]
    *   - {String} unit - which unit you want to connect, default is current unit
    * @returns {Promise<object>} result
+   * @deprecated This API is not implemented and will be removed in a future version.
+   * Nacos server does not support batch configuration retrieval operations.
+   * Please use individual getConfig() calls instead.
    */
   batchGetConfig(dataIds: string[], group: string, options?: UnitOptions): Promise<object>;
 
@@ -150,6 +155,9 @@ export interface IClientWorker {
    * @param {Object} [options]
    *   - {String} unit - which unit you want to connect, default is current unit
    * @returns {Promise<object>} result
+   * @deprecated This API is not implemented and will be removed in a future version.
+   * Nacos server does not support batch query operations.
+   * Please use individual query methods instead.
    */
   batchQuery(dataIds: string[], group: string, options?: UnitOptions): Promise<object>;
 


### PR DESCRIPTION
Fixes #67 