### PR TITLE
fix(nacos-config): rotate server list on retry; pointer was stuck on dead IP

### DIFF
--- a/packages/nacos-config/src/server_list_mgr.ts
+++ b/packages/nacos-config/src/server_list_mgr.ts
@@ -166,9 +166,9 @@ export class ServerListManager extends Base implements IServerListManager {
     if (this.isSync || this.isDirectMode) {
       return;
     }
+    this.isSync = true;
     (async () => {
       try {
-        this.isSync = true;
         while (!this.isClosed) {
           await sleep(this.refreshInterval);
           const units = Array.from(this.serverListCache.keys());
@@ -182,9 +182,13 @@ export class ServerListManager extends Base implements IServerListManager {
             }
           }
         }
-        this.isSync = false;
       } catch (err) {
         this.emit('error', err);
+      } finally {
+        // Always reset the flag, whether the loop exits normally or
+        // throws, so that subsequent syncServers() calls are not
+        // permanently short-circuited.
+        this.isSync = false;
       }
     })();
   }
@@ -260,14 +264,18 @@ export class ServerListManager extends Base implements IServerListManager {
     if (!this.serverListCache.has(unit)) {
       await this.fetchServerList(unit);
     }
-    let serverData = this.serverListCache.get(unit);
-    if (serverData) {
+    const serverData = this.serverListCache.get(unit);
+    if (serverData && serverData.hosts && serverData.hosts.length) {
       let currentHostIndex = serverData.index;
-      if (currentHostIndex >= serverData.hosts.length) {
+      if (currentHostIndex >= serverData.hosts.length || currentHostIndex < 0) {
         // 超出序号，重头开始循环
         currentHostIndex = 0;
       }
-      const currentServer = serverData.hosts[ currentHostIndex++ ];
+      const currentServer = serverData.hosts[ currentHostIndex ];
+      // Write the next index back to the cache so that retries after a
+      // failed request can actually rotate to the next server.
+      serverData.index = (currentHostIndex + 1) % serverData.hosts.length;
+      this.serverListCache.set(unit, serverData);
       this.currentServerAddrMap.set(unit, currentServer);
     }
   }

--- a/packages/nacos-config/test/server_list_mgr.test.ts
+++ b/packages/nacos-config/test/server_list_mgr.test.ts
@@ -73,11 +73,32 @@ describe('test/server_list_mgr.test.ts', () => {
       });
 
       it('should traverse all diamond server list data', async () => {
+        // First call initializes currentServerAddrMap and serverListCache.
         const start = await serverManager.getCurrentServerAddr();
-        let host;
-        do {
+        assert(start);
+        const cacheData = serverManager.getServerInCache();
+        assert(cacheData && cacheData.hosts && cacheData.hosts.length > 0);
+        const total = cacheData.hosts.length;
+        // Drive rotation explicitly via updateCurrentServer. Every one of
+        // the first `total - 1` rotations must return a host that has not
+        // been seen yet; otherwise the round-robin pointer is not really
+        // advancing and the test must fail.
+        const seen = new Set<string>();
+        seen.add(start);
+        let host = start;
+        for (let i = 0; i < total - 1; i++) {
+          await serverManager.updateCurrentServer();
           host = await serverManager.getCurrentServerAddr();
-        } while (start !== host);
+          assert(!seen.has(host),
+            `rotation revisited ${host} before covering all hosts`);
+          seen.add(host);
+        }
+        // After visiting every host exactly once, one more rotation must
+        // wrap back to the starting host.
+        await serverManager.updateCurrentServer();
+        host = await serverManager.getCurrentServerAddr();
+        assert(seen.size === total);
+        assert(host === start);
       });
 
       it('should return null when server list return empty', async () => {
@@ -246,15 +267,18 @@ describe('test/server_list_mgr.test.ts', () => {
 
     it('should round-robin through all servers', async () => {
       const servers = [];
-      for (let i = 0; i < 5; i++) {
-        const addr = await serverManager.getCurrentServerAddr();
-        servers.push(addr);
+      // The first getCurrentServerAddr() triggers one updateCurrentServer().
+      servers.push(await serverManager.getCurrentServerAddr());
+      // Subsequent rotation must be driven explicitly via updateCurrentServer().
+      for (let i = 0; i < 4; i++) {
+        await serverManager.updateCurrentServer();
+        servers.push(await serverManager.getCurrentServerAddr());
       }
       // Should cycle through all 3 servers
       assert(servers[ 0 ] === '127.0.0.1:8848');
       assert(servers[ 1 ] === '127.0.0.2:8848');
       assert(servers[ 2 ] === '127.0.0.3:8848');
-      assert(servers[ 3 ] === '127.0.0.1:8848'); //循环 restart
+      assert(servers[ 3 ] === '127.0.0.1:8848'); // cycle restart
       assert(servers[ 4 ] === '127.0.0.2:8848');
     });
   });
@@ -289,14 +313,17 @@ describe('test/server_list_mgr.test.ts', () => {
 
     it('should round-robin through comma-separated servers', async () => {
       const servers = [];
-      for (let i = 0; i < 4; i++) {
-        const addr = await serverManager.getCurrentServerAddr();
-        servers.push(addr);
+      // The first getCurrentServerAddr() triggers one updateCurrentServer().
+      servers.push(await serverManager.getCurrentServerAddr());
+      // Subsequent rotation must be driven explicitly via updateCurrentServer().
+      for (let i = 0; i < 3; i++) {
+        await serverManager.updateCurrentServer();
+        servers.push(await serverManager.getCurrentServerAddr());
       }
       assert(servers[ 0 ] === '127.0.0.1:8848');
       assert(servers[ 1 ] === '127.0.0.2:8848');
       assert(servers[ 2 ] === '127.0.0.3:8848');
-      assert(servers[ 3 ] === '127.0.0.1:8848'); //循环 restart
+      assert(servers[ 3 ] === '127.0.0.1:8848'); // cycle restart
     });
   });
 });


### PR DESCRIPTION
## Problem

In address-server (endpoint) mode of `nacos-config`, when the currently selected Nacos server IP becomes unreachable, the SDK keeps hitting the same dead IP within the whole request-retry window and eventually fails with a timeout. It never rotates to the next server in the list.

Root cause is in `ServerListManager.updateCurrentServer()`:

```ts
const currentServer = serverData.hosts[ currentHostIndex++ ];
this.currentServerAddrMap.set(unit, currentServer);
```

`currentHostIndex++` is a post-increment on a **local variable**; the updated value is never written back to `serverData.index`. So every call to `updateCurrentServer()` re-reads the same `serverData.index` and returns the same host. The retry loop in `HttpAgent.request()` calls `updateCurrentServer` after each failure, but because the pointer never moves, every retry targets the same dead IP until `Date.now() >= endTime`.

As a side effect, a separate bug in `syncServers()` — the `isSync` flag is not reset if the while loop throws — can silently disable all subsequent `syncServers()` calls.

## Fix

- `updateCurrentServer`: write the next index back to `serverData.index` via `(currentHostIndex + 1) % hosts.length`, so retries genuinely rotate. Also guard against empty `hosts` and negative index to avoid `NaN` from `% 0`.
- `syncServers`: move `isSync = true` before the IIFE and reset it in a `finally` block, so an exception out of the while loop can no longer leave the flag stuck and block future sync invocations.

## Tests

Updated `test/server_list_mgr.test.ts`:

- The previous `should traverse all diamond server list data` test only called `getCurrentServerAddr()` repeatedly, which returns the cached address without advancing — so the loop exited on the first iteration and never exercised rotation. Now it drives rotation explicitly via `updateCurrentServer()` and asserts the pointer returns to the starting host after `hosts.length` steps.
- The two `round-robin` tests in direct mode were failing to verify rotation for the same reason; updated to call `updateCurrentServer()` between reads.
- Direct-mode round-robin tests are deterministic and fully local.

## Compatibility

- Public API signatures unchanged.
- Normal (success) request path unchanged — `HttpAgent.request()` only invokes `updateCurrentServer()` on failure.
- Only the retry path behavior changes, which is the bug being fixed.
- `nacos-naming` package is a separate implementation and is not affected.
