### PR TITLE
feat: add selectOneHealthyInstance to naming client (align with Java SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ gRPC advantages over HTTP:
   - [clusters] {String} Cluster names
   - [healthy] {Boolean} filter healthy instances, default is true
   - [subscribe] {Boolean} whether subscribe the service, default is true
+- `selectOneHealthyInstance(serviceName, [groupName], [clusters], [subscribe])` Select one healthy instance of service with weighted random load balancing (aligned with the Java SDK `NamingService#selectOneHealthyInstance`). Returns null when no healthy and enabled instance with a positive weight is available.
+  - serviceName {String} Service name
+  - [groupName] {String} group name, default is `DEFAULT_GROUP`
+  - [clusters] {String} Cluster names
+  - [subscribe] {Boolean} whether subscribe the service, default is true
 - `getServerStatus()` Get the status of nacos server, 'UP' or 'DOWN'.
 - `subscribe(info, listener)` Subscribe the instances of the service
   - info {Object|String} service info, if type is string, it's the serviceName

--- a/packages/nacos-naming/src/naming/client.ts
+++ b/packages/nacos-naming/src/naming/client.ts
@@ -28,7 +28,7 @@ import { GrpcNamingProxy } from './grpc_proxy';
 import { BeatReactor } from './beat_reactor';
 import { HostReactor } from './host_reactor';
 import { NacosNamingClientOptions, Host, SubscribeInfo, BeatInfo } from '../interface';
-import { getGroupedName } from '../utils';
+import { getGroupedName, chooseHostByWeight } from '../utils';
 import { DEFAULT_GROUP } from '../const';
 
 const defaultOptions = {
@@ -172,6 +172,17 @@ export class NacosNamingClient extends Base {
     return serviceInfo.hosts.filter((host: Host) => {
       return host.healthy === healthy && host.enabled && host.weight > 0;
     });
+  }
+
+  /**
+   * Select one healthy instance with weighted random load balancing,
+   * aligned with the Java SDK `NamingService#selectOneHealthyInstance`.
+   * Returns null when there is no healthy and enabled instance
+   * with a positive weight.
+   */
+  async selectOneHealthyInstance(serviceName: string, groupName: string = DEFAULT_GROUP, clusters: string = '', subscribe: boolean = true): Promise<Host | null> {
+    const hosts = await this.selectInstances(serviceName, groupName, clusters, true, subscribe);
+    return chooseHostByWeight(hosts);
   }
 
   async getServerStatus(): Promise<string> {

--- a/packages/nacos-naming/src/utils.ts
+++ b/packages/nacos-naming/src/utils.ts
@@ -21,6 +21,7 @@ const zlib = require('zlib');
 const crypto = require('crypto');
 /* tslint:enable:no-var-requires */
 import { SERVICE_INFO_SPLITER, DEFAULT_GROUP } from './const';
+import { Host } from './interface';
 
 const GZIP_MAGIC = 35615;
 
@@ -60,4 +61,33 @@ export function getGroupName(serviceNameWithGroup: string): string {
     return DEFAULT_GROUP;
   }
   return serviceNameWithGroup.split(SERVICE_INFO_SPLITER)[0];
+}
+
+/**
+ * Select one host from the list using weighted random selection,
+ * aligned with the Java SDK `NamingUtils#selectOneWithWeight`.
+ * Every host is expected to carry a positive weight; a host with a
+ * larger weight is proportionally more likely to be picked.
+ * Returns null when the list is empty.
+ */
+export function chooseHostByWeight(hosts: Host[]): Host | null {
+  if (!hosts || hosts.length === 0) {
+    return null;
+  }
+  if (hosts.length === 1) {
+    return hosts[0];
+  }
+  let totalWeight = 0;
+  for (const host of hosts) {
+    totalWeight += host.weight;
+  }
+  const random = Math.random() * totalWeight;
+  let currentWeight = 0;
+  for (const host of hosts) {
+    currentWeight += host.weight;
+    if (random < currentWeight) {
+      return host;
+    }
+  }
+  return hosts[hosts.length - 1];
 }

--- a/packages/nacos-naming/test/naming/select_one_healthy_instance.test.ts
+++ b/packages/nacos-naming/test/naming/select_one_healthy_instance.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import * as mm from 'mm';
+import { NacosNamingClient } from '../../src/naming/client';
+import { Host } from '../../src/interface';
+import { chooseHostByWeight } from '../../src/utils';
+
+const logger = console;
+
+function host(ip: string, weight: number, healthy: boolean = true, enabled: boolean = true): Host {
+  return { ip, port: 8080, weight, healthy, enabled };
+}
+
+describe('test/naming/select_one_healthy_instance.test.ts', () => {
+  afterEach(mm.restore);
+
+  describe('chooseHostByWeight', () => {
+    it('should return null for an empty list', () => {
+      assert.strictEqual(chooseHostByWeight([]), null);
+    });
+
+    it('should return the only host for a single-element list', () => {
+      const onlyHost = host('1.1.1.1', 1);
+      assert.strictEqual(chooseHostByWeight([ onlyHost ]), onlyHost);
+    });
+
+    it('should distribute selections proportionally to weights', () => {
+      const hosts = [ host('1.1.1.1', 1), host('2.2.2.2', 3) ];
+      const counts: Record<string, number> = {};
+      for (let i = 0; i < 4000; i++) {
+        const picked = chooseHostByWeight(hosts) as Host;
+        counts[picked.ip] = (counts[picked.ip] || 0) + 1;
+      }
+      // Expected ratio is 1:3; keep a loose bound to avoid flakes.
+      const ratio = counts['2.2.2.2'] / counts['1.1.1.1'];
+      assert(ratio > 2.2 && ratio < 4.0, `unexpected ratio: ${ratio}`);
+    });
+  });
+
+  describe('NacosNamingClient#selectOneHealthyInstance', () => {
+    it('should pick one healthy, enabled host with positive weight', async () => {
+      const client = new NacosNamingClient({
+        logger,
+        serverList: '127.0.0.1:8848',
+        transport: 'http',
+      });
+      client.on('error', () => { /* ignore background errors in unit test */ });
+      mm(client as any, '_hostReactor', {
+        getServiceInfo: async () => ({
+          hosts: [
+            host('1.1.1.1', 1),
+            host('2.2.2.2', 0),
+            host('3.3.3.3', 1, false),
+            host('4.4.4.4', 1, true, false),
+          ],
+        }),
+      });
+      const selected = await client.selectOneHealthyInstance('test-service');
+      assert(selected);
+      assert.strictEqual((selected as Host).ip, '1.1.1.1');
+    });
+
+    it('should return null when there is no healthy host', async () => {
+      const client = new NacosNamingClient({
+        logger,
+        serverList: '127.0.0.1:8848',
+        transport: 'http',
+      });
+      client.on('error', () => { /* ignore background errors in unit test */ });
+      mm(client as any, '_hostReactor', {
+        getServiceInfo: async () => ({ hosts: [] }),
+      });
+      const selected = await client.selectOneHealthyInstance('test-service');
+      assert.strictEqual(selected, null);
+    });
+  });
+});


### PR DESCRIPTION
## What is the purpose of the change

Align the Node SDK with the Java SDK: add `NamingService#selectOneHealthyInstance` to the naming client.

The Java SDK provides `selectOneHealthyInstance` for client-side load balancing (pick one healthy instance by weighted random), but the Node SDK only has `selectInstances`. This PR closes that gap with the minimal, dependency-free implementation.

## Brief changelog

- `chooseHostByWeight(hosts)` in `packages/nacos-naming/src/utils.ts`: weighted random selection aligned with Java `NamingUtils#selectOneWithWeight` (larger weight -> proportionally more likely).
- `NacosNamingClient#selectOneHealthyInstance(serviceName, [groupName], [clusters], [subscribe])`: reuses `selectInstances` filtering (healthy, enabled, weight > 0) and returns one host, or `null` when none is available.
- Unit tests (`test/naming/select_one_healthy_instance.test.ts`) that need no live Nacos server: empty/single list, weight distribution, client-level filtering. Verified locally with `midway-bin test --ts` (5 passing), plus the existing unit tests still pass and `pnpm -r run build` succeeds.
- README API doc updated.

Note for maintainers: the new test file can be appended to the `Run unit tests (nacos-naming)` file list in `.github/workflows/ci.yml` (I could not include the workflow change here due to token scope).

## Verifying this change

Tests only run against mocked `HostReactor`, no live server needed:

```bash
cd packages/nacos-naming
npx midway-bin test --ts -- --file test/naming/select_one_healthy_instance.test.ts --timeout 30000
```

Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Make sure there is a [GitHub issue](https://github.com/nacos-group/nacos-sdk-nodejs/issues) filed for the change (this is a feature alignment with the Java SDK; happy to open an issue first if preferred)
- [x] Write a pull request description
- [x] Write necessary unit tests
