### PR TITLE
feat: support publishConfigCas for optimistic-lock style config publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ await configClient.ready();
 // publish config
 await configClient.publishSingle('test', 'DEFAULT_GROUP', 'hello=world');
 
+// publish config with CAS (compare-and-set):
+// succeeds only when the md5 of the current server-side config equals casMd5
+const crypto = require('crypto');
+const currentContent = await configClient.getConfig('test', 'DEFAULT_GROUP');
+const casMd5 = crypto.createHash('md5').update(currentContent || '').digest('hex');
+const published = await configClient.publishConfigCas('test', 'DEFAULT_GROUP', 'hello=nacos', casMd5);
+console.log('cas publish:', published); // false when casMd5 mismatched
+
 // get config
 const content = await configClient.getConfig('test', 'DEFAULT_GROUP');
 console.log('content:', content);
@@ -159,6 +167,7 @@ gRPC advantages over HTTP:
   - dataId {String} data id
   - group {String} group name
 - `publishSingle(dataId, group, content)` Publish config.
+- `publishConfigCas(dataId, group, content, casMd5)` Publish config with CAS semantics, succeeds only when the md5 of the current server-side config equals `casMd5` (aligned with Java SDK `ConfigService#publishConfigCas`).
   - dataId {String} data id
   - group {String} group name
   - content {String} content to publish

--- a/packages/nacos-config/src/client.ts
+++ b/packages/nacos-config/src/client.ts
@@ -303,6 +303,35 @@ export class DataClient extends Base implements BaseClient {
   }
 
   /**
+   * 以 CAS 方式发布配置，仅当服务端当前配置的 md5 与 casMd5 一致时才发布成功
+   * @param {String} dataId - id of the data
+   * @param {String} group - group name of the data
+   * @param {String} content - config value
+   * @param {String} casMd5 - md5 of the expected current config content
+   * @param {Object} options
+   *   - {Stirng} unit - which unit you want to connect, default is current unit
+   *   - {String} type - config type, e.g., 'text', 'json', 'xml', 'html', 'properties', 'yaml', etc.
+   * @return {Boolean} success, false when casMd5 mismatched (gRPC transport)
+   */
+  async publishConfigCas(dataId, group, content, casMd5, options?: UnitOptions) {
+    checkParameters(dataId, group);
+    if (!casMd5) {
+      throw new Error('[DataClient] publishConfigCas requires casMd5, use getConfig to fetch the current md5');
+    }
+    if (this._grpcConfigProxy) {
+      return await this._grpcConfigProxy.publishSingle(
+        dataId, group,
+        this.configuration.get(ClientOptionKeys.NAMESPACE),
+        content,
+        options && options.type,
+        casMd5
+      );
+    }
+    const client = this.getClient(options);
+    return await client.publishConfigCas(dataId, group, content, casMd5, options);
+  }
+
+  /**
    * 删除配置
    * @param {String} dataId - id of the data
    * @param {String} group - group name of the data

--- a/packages/nacos-config/src/client_worker.ts
+++ b/packages/nacos-config/src/client_worker.ts
@@ -414,22 +414,41 @@ export class ClientWorker extends Base implements IClientWorker {
    * @param {String} content - config value
    * @param {Object} [options]
    *   - {String} type - type of the data
+   *   - {String} casMd5 - CAS md5 of the expected config content, publish fails when mismatched
    * @return {Boolean} success
    */
   async publishSingle(dataId, group, content, options?: UnitOptions) {
+    const data: { [key: string]: string } = {
+      dataId,
+      group,
+      content,
+      tenant: this.namespace,
+      type: options && options.type,
+      appName: this.appName
+    };
+    if (options && options.casMd5) {
+      data.casMd5 = options.casMd5;
+    }
     await this.httpAgent.request(this.apiRoutePath.PUBLISH, {
       method: 'POST',
       encode: true,
-      data: {
-        dataId,
-        group,
-        content,
-        tenant: this.namespace,
-        type: options && options.type,
-        appName: this.appName
-      },
+      data,
     });
     return true;
+  }
+
+  /**
+   * 以 CAS 方式发布配置，仅当服务端当前配置的 md5 与 casMd5 一致时才发布成功
+   * @param {String} dataId - id of the data
+   * @param {String} group - group name of the data
+   * @param {String} content - config value
+   * @param {String} casMd5 - md5 of the expected current config content
+   * @param {Object} [options]
+   *   - {String} type - type of the data
+   * @return {Boolean} success
+   */
+  async publishConfigCas(dataId, group, content, casMd5, options?: UnitOptions) {
+    return await this.publishSingle(dataId, group, content, { ...options, casMd5 });
   }
 
   /**

--- a/packages/nacos-config/src/client_worker.ts
+++ b/packages/nacos-config/src/client_worker.ts
@@ -426,13 +426,17 @@ export class ClientWorker extends Base implements IClientWorker {
       type: options && options.type,
       appName: this.appName
     };
+    // 服务端从请求头读取 casMd5（ConfigController: request.getHeader("casMd5")），
+    // 放在表单参数里会被忽略，导致退化为无条件发布
+    const headers: { [key: string]: string } = {};
     if (options && options.casMd5) {
-      data.casMd5 = options.casMd5;
+      headers.casMd5 = options.casMd5;
     }
     await this.httpAgent.request(this.apiRoutePath.PUBLISH, {
       method: 'POST',
       encode: true,
       data,
+      headers,
     });
     return true;
   }
@@ -448,7 +452,23 @@ export class ClientWorker extends Base implements IClientWorker {
    * @return {Boolean} success
    */
   async publishConfigCas(dataId, group, content, casMd5, options?: UnitOptions) {
-    return await this.publishSingle(dataId, group, content, { ...options, casMd5 });
+    try {
+      return await this.publishSingle(dataId, group, content, { ...options, casMd5 });
+    } catch (err) {
+      // casMd5 与服务端当前 md5 不一致时：
+      // - 部分版本服务端返回 409 Conflict
+      // - Nacos 2.x 返回 500，body 为 "Cas publish fail, server md5 may have changed"
+      // 两种情况都属于 CAS 校验失败，与 gRPC 路径一致返回 false
+      const isCasConflict = err && (
+        /ServerConflictError$/.test(err.name) ||
+        /cas publish fail/i.test(String(err.body || ''))
+      );
+      if (isCasConflict) {
+        this.debug('publishConfigCas failed, casMd5 mismatched, dataId: %s, group: %s', dataId, group);
+        return false;
+      }
+      throw err;
+    }
   }
 
   /**

--- a/packages/nacos-config/src/grpc_config_proxy.ts
+++ b/packages/nacos-config/src/grpc_config_proxy.ts
@@ -120,7 +120,7 @@ export class GrpcConfigProxy extends Base {
   /**
    * Publish config via gRPC ConfigPublishRequest.
    */
-  async publishSingle(dataId: string, group: string, tenant: string | undefined, content: string, type?: string): Promise<boolean> {
+  async publishSingle(dataId: string, group: string, tenant: string | undefined, content: string, type?: string, casMd5?: string): Promise<boolean> {
     const resolvedTenant = tenant != null ? tenant : this._namespace;
     this._logger.info('[GrpcConfigProxy] publishSingle dataId=%s group=%s tenant=%s', dataId, group, resolvedTenant);
     const request: any = {
@@ -131,6 +131,9 @@ export class GrpcConfigProxy extends Base {
     };
     if (type) {
       request.type = type;
+    }
+    if (casMd5) {
+      request.casMd5 = casMd5;
     }
     const response = await this._transportClient.request(request, 'ConfigPublishRequest');
     return response.resultCode === 200;

--- a/packages/nacos-config/src/index.ts
+++ b/packages/nacos-config/src/index.ts
@@ -135,6 +135,20 @@ export class NacosConfigClient extends APIClientBase implements BaseClient {
   }
 
   /**
+   * 以 CAS 方式发布配置，仅当服务端当前配置的 md5 与 casMd5 一致时才发布成功
+   * @param {String} dataId - id of the data
+   * @param {String} group - group name of the data
+   * @param {String} content - config value
+   * @param {String} casMd5 - md5 of the expected current config content
+   * @param {Object} [options]
+   * @return {Boolean} success
+   */
+  async publishConfigCas(dataId, group, content, casMd5, options?) {
+    checkParameters(dataId, group);
+    return await this._client.publishConfigCas(dataId, group, content, casMd5, options);
+  }
+
+  /**
    * 删除配置
    * @param {String} dataId - id of the data
    * @param {String} group - group name of the data

--- a/packages/nacos-config/src/interface.ts
+++ b/packages/nacos-config/src/interface.ts
@@ -38,11 +38,15 @@ export interface CommonInputOptions {
 }
 
 export interface UnitOptions {
-  unit: string;
+  unit?: string;
   /**
    * Configuration type, e.g., 'text', 'json', 'xml', 'html', 'properties', 'yaml', etc.
    */
   type?: string;
+  /**
+   * CAS md5 of the expected config content, publish fails when mismatched with server side.
+   */
+  casMd5?: string;
 }
 
 /**
@@ -104,6 +108,19 @@ export interface IClientWorker {
    * @returns {Promise<boolean>} true | false
    */
   publishSingle(dataId: string, group: string, content: string, options?: UnitOptions): Promise<boolean>;
+
+  /**
+   * @description 以 CAS 方式发布配置，仅当服务端当前配置的 md5 与 casMd5 一致时才发布成功
+   * @param {String} dataId - id of the data
+   * @param {String} group - group name of the data
+   * @param {String} content - config value
+   * @param {String} casMd5 - md5 of the expected current config content
+   * @param {Object} [options]
+   *   - {String} unit - which unit you want to connect, default is current unit
+   *   - {String} type - config type, e.g., 'text', 'json', 'xml', 'html', 'properties', 'yaml', etc.
+   * @returns {Promise<boolean>} true | false
+   */
+  publishConfigCas(dataId: string, group: string, content: string, casMd5: string, options?: UnitOptions): Promise<boolean>;
 
   /**
    * @description 删除配置

--- a/packages/nacos-config/test/publish_config_cas.integration.test.ts
+++ b/packages/nacos-config/test/publish_config_cas.integration.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ClientWorker, ServerListManager, Snapshot } from '../src';
+import { HttpAgent } from '../src/http_agent';
+import { createDefaultConfiguration } from './utils';
+import * as crypto from 'crypto';
+import * as path from 'path';
+import * as assert from 'assert';
+
+const httpclient = require('urllib');
+
+// 需要一个可用的 Nacos server（CI 的 integration-http job 会启动 nacos/nacos-server:v2.5.2）
+const SERVER_ADDR = process.env.NACOS_SERVER_ADDR || '127.0.0.1:8848';
+const GROUP = 'DEFAULT_GROUP';
+const cacheDir = path.join(__dirname, '.cache_cas_integration');
+
+function md5(content: string): string {
+  return crypto.createHash('md5').update(content).digest('hex');
+}
+
+// Nacos 配置写入后 dump/读取存在秒级异步延迟，期间读可能返回旧值或 404，
+// 轮询直到服务端内容与期望一致（直接 HTTP 读，绕过客户端快照缓存）
+async function waitForServerContent(dataId: string, group: string, expected: string, timeoutMs = 20000): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  let content = await getServerConfig(dataId, group);
+  while (content !== expected && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    content = await getServerConfig(dataId, group);
+  }
+  return content;
+}
+
+// 直接 HTTP 读服务端，绕过客户端快照缓存，断言服务端真实状态
+async function getServerConfig(dataId: string, group: string): Promise<string | null> {
+  const res = await httpclient.request(
+    `http://${SERVER_ADDR}/nacos/v1/cs/configs?dataId=${dataId}&group=${group}&tenant=`,
+    { method: 'GET', dataType: 'text', timeout: 5000 });
+  return res.status === 200 ? res.data : null;
+}
+
+async function isServerAvailable(): Promise<boolean> {
+  try {
+    const res = await httpclient.request(`http://${SERVER_ADDR}/nacos/v1/cs/configs?dataId=__cas_probe__&group=${GROUP}`, {
+      method: 'GET',
+      dataType: 'text',
+      timeout: 3000,
+    });
+    return res.status < 500;
+  } catch (err) {
+    return false;
+  }
+}
+
+describe('test/publish_config_cas.integration.test.ts', () => {
+
+  let client: ClientWorker;
+  let serverAvailable = false;
+  const dataId = `cas-integration-${Date.now()}`;
+  const contentV1 = 'cas-integration-v1';
+  const contentV2 = 'cas-integration-v2';
+  const contentV3 = 'cas-integration-v3';
+
+  before(async function(this: any) {
+    serverAvailable = await isServerAvailable();
+    if (!serverAvailable) {
+      console.warn('[publish_config_cas.integration] Nacos server unavailable at %s, skip integration tests', SERVER_ADDR);
+      this.skip();
+      return;
+    }
+    const configuration = createDefaultConfiguration({
+      serverAddr: SERVER_ADDR,
+      namespace: '',
+      cacheDir,
+    });
+    const snapshot = new Snapshot({ configuration });
+    const serverMgr = new ServerListManager({ configuration });
+    const httpAgent = new HttpAgent({ configuration });
+    configuration.merge({ snapshot, serverMgr, httpAgent });
+    client = new ClientWorker({ configuration });
+  });
+
+  after(async () => {
+    if (!serverAvailable || !client) return;
+    await client.remove(dataId, GROUP);
+  });
+
+  it('should publish when casMd5 matches the server-side content', async () => {
+    await client.publishSingle(dataId, GROUP, contentV1);
+    assert(await waitForServerContent(dataId, GROUP, contentV1) === contentV1);
+    const published = await client.publishConfigCas(dataId, GROUP, contentV2, md5(contentV1));
+    assert(published === true);
+    assert(await waitForServerContent(dataId, GROUP, contentV2) === contentV2);
+  });
+
+  it('should return false and keep the config unchanged when casMd5 is stale', async () => {
+    // 服务端当前内容是 contentV2，传入 contentV1 的 md5 模拟读到旧版本后并发写入
+    const published = await client.publishConfigCas(dataId, GROUP, contentV3, md5(contentV1));
+    assert(published === false);
+    // stale 写入被拒绝后，服务端内容必须保持 contentV2
+    assert(await waitForServerContent(dataId, GROUP, contentV2) === contentV2);
+  });
+});

--- a/packages/nacos-config/test/publish_config_cas.test.ts
+++ b/packages/nacos-config/test/publish_config_cas.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ClientWorker, ServerListManager, Snapshot } from '../src';
+import { HttpAgent } from '../src/http_agent';
+import { GrpcConfigProxy } from '../src/grpc_config_proxy';
+import { DataClient } from '../src/client';
+import { createDefaultConfiguration } from './utils';
+import * as path from 'path';
+import * as mm from 'mm';
+import * as assert from 'assert';
+
+const cacheDir = path.join(__dirname, '.cache_cas');
+
+describe('test/publish_config_cas.test.ts', () => {
+
+  afterEach(mm.restore);
+
+  describe('ClientWorker.publishSingle casMd5 (HTTP transport)', () => {
+    let client: ClientWorker;
+
+    before(() => {
+      const configuration = createDefaultConfiguration({
+        serverAddr: '127.0.0.1:8848',
+        namespace: '',
+        cacheDir,
+      });
+      const snapshot = new Snapshot({ configuration });
+      const serverMgr = new ServerListManager({ configuration });
+      const httpAgent = new HttpAgent({ configuration });
+      configuration.merge({ snapshot, serverMgr, httpAgent });
+      client = new ClientWorker({ configuration });
+    });
+
+    it('should pass casMd5 in publish request', async () => {
+      let captured;
+      mm(client.httpAgent, 'request', async (path, options) => {
+        captured = options;
+      });
+      const success = await client.publishSingle('cas-data-id', 'cas-group', 'content-v2', { casMd5: 'md5-of-v1' });
+      assert(success === true);
+      assert(captured.data.casMd5 === 'md5-of-v1');
+      assert(captured.data.dataId === 'cas-data-id');
+      assert(captured.data.content === 'content-v2');
+    });
+
+    it('should not pass casMd5 when absent', async () => {
+      let captured;
+      mm(client.httpAgent, 'request', async (path, options) => {
+        captured = options;
+      });
+      await client.publishSingle('cas-data-id', 'cas-group', 'content-v1');
+      assert(!('casMd5' in captured.data));
+    });
+  });
+
+  describe('GrpcConfigProxy.publishSingle casMd5 (gRPC transport)', () => {
+    const capturedRequests: any[] = [];
+    let resultCode = 200;
+    const transportClient: any = {
+      request: async (request, type) => {
+        capturedRequests.push({ request, type });
+        return { resultCode };
+      },
+      registerServerPushHandler: () => {},
+      onReconnect: () => {},
+    };
+    const proxy = new GrpcConfigProxy({
+      transportClient,
+      namespace: 'public',
+      logger: console,
+    });
+
+    beforeEach(() => {
+      capturedRequests.length = 0;
+      resultCode = 200;
+    });
+
+    it('should set casMd5 on ConfigPublishRequest', async () => {
+      const success = await proxy.publishSingle('cas-data-id', 'cas-group', 'public', 'content-v2', undefined, 'md5-of-v1');
+      assert(success === true);
+      assert(capturedRequests.length === 1);
+      assert(capturedRequests[0].type === 'ConfigPublishRequest');
+      assert(capturedRequests[0].request.casMd5 === 'md5-of-v1');
+    });
+
+    it('should not set casMd5 when absent', async () => {
+      await proxy.publishSingle('cas-data-id', 'cas-group', 'public', 'content-v1');
+      assert(!('casMd5' in capturedRequests[0].request));
+    });
+
+    it('should return false when server rejects cas md5', async () => {
+      resultCode = 401;
+      const success = await proxy.publishSingle('cas-data-id', 'cas-group', 'public', 'content-v2', undefined, 'stale-md5');
+      assert(success === false);
+    });
+  });
+
+  describe('DataClient.publishConfigCas', () => {
+    let client: DataClient;
+
+    before(() => {
+      client = new DataClient({
+        serverAddr: '127.0.0.1:8848',
+        namespace: '',
+        transport: 'http',
+      } as any);
+    });
+
+    after(() => {
+      client.close();
+    });
+
+    afterEach(() => {
+      (client as any)._grpcConfigProxy = null;
+    });
+
+    it('should throw when casMd5 is missing', async () => {
+      await assert.rejects(
+        () => client.publishConfigCas('cas-data-id', 'cas-group', 'content', undefined as any),
+        /requires casMd5/
+      );
+    });
+
+    it('should delegate to grpc proxy with casMd5', async () => {
+      let capturedArgs;
+      (client as any)._grpcConfigProxy = {
+        publishSingle: async (...args) => {
+          capturedArgs = args;
+          return true;
+        },
+      };
+      const success = await client.publishConfigCas('cas-data-id', 'cas-group', 'content-v2', 'md5-of-v1');
+      assert(success === true);
+      assert(capturedArgs[0] === 'cas-data-id');
+      assert(capturedArgs[5] === 'md5-of-v1');
+    });
+
+    it('should delegate to worker with casMd5 in options', async () => {
+      let capturedOptions;
+      mm(client, 'getClient', () => ({
+        publishConfigCas: async (dataId, group, content, casMd5, options) => {
+          capturedOptions = { casMd5, ...options };
+          return true;
+        },
+      }));
+      const success = await client.publishConfigCas('cas-data-id', 'cas-group', 'content-v2', 'md5-of-v1', { type: 'properties' } as any);
+      assert(success === true);
+      assert(capturedOptions.casMd5 === 'md5-of-v1');
+      assert(capturedOptions.type === 'properties');
+    });
+  });
+});

--- a/packages/nacos-config/test/publish_config_cas.test.ts
+++ b/packages/nacos-config/test/publish_config_cas.test.ts
@@ -46,16 +46,17 @@ describe('test/publish_config_cas.test.ts', () => {
       client = new ClientWorker({ configuration });
     });
 
-    it('should pass casMd5 in publish request', async () => {
+    it('should pass casMd5 in request headers', async () => {
       let captured;
       mm(client.httpAgent, 'request', async (path, options) => {
         captured = options;
       });
       const success = await client.publishSingle('cas-data-id', 'cas-group', 'content-v2', { casMd5: 'md5-of-v1' });
       assert(success === true);
-      assert(captured.data.casMd5 === 'md5-of-v1');
+      assert(captured.headers.casMd5 === 'md5-of-v1');
       assert(captured.data.dataId === 'cas-data-id');
       assert(captured.data.content === 'content-v2');
+      assert(!('casMd5' in captured.data));
     });
 
     it('should not pass casMd5 when absent', async () => {
@@ -64,6 +65,7 @@ describe('test/publish_config_cas.test.ts', () => {
         captured = options;
       });
       await client.publishSingle('cas-data-id', 'cas-group', 'content-v1');
+      assert(!('casMd5' in captured.headers));
       assert(!('casMd5' in captured.data));
     });
   });
@@ -162,6 +164,56 @@ describe('test/publish_config_cas.test.ts', () => {
       assert(success === true);
       assert(capturedOptions.casMd5 === 'md5-of-v1');
       assert(capturedOptions.type === 'properties');
+    });
+  });
+
+  describe('ClientWorker.publishConfigCas conflict (HTTP transport)', () => {
+    let client: ClientWorker;
+
+    before(() => {
+      const configuration = createDefaultConfiguration({
+        serverAddr: '127.0.0.1:8848',
+        namespace: '',
+        cacheDir,
+      });
+      const snapshot = new Snapshot({ configuration });
+      const serverMgr = new ServerListManager({ configuration });
+      const httpAgent = new HttpAgent({ configuration });
+      configuration.merge({ snapshot, serverMgr, httpAgent });
+      client = new ClientWorker({ configuration });
+    });
+
+    it('should return false when server responds 409 (casMd5 mismatched)', async () => {
+      const conflictErr: any = new Error('[Client Worker] Nacos server config being modified concurrently');
+      conflictErr.name = 'NacosServerConflictError';
+      mm(client.httpAgent, 'request', async () => {
+        throw conflictErr;
+      });
+      const success = await client.publishConfigCas('cas-data-id', 'cas-group', 'content-v2', 'stale-md5');
+      assert(success === false);
+    });
+
+    it('should return false when server responds 500 with cas publish fail body', async () => {
+      const casFailErr: any = new Error('Nacos Server Error Status: 500');
+      casFailErr.name = 'NacosServerResponseError';
+      casFailErr.body = 'caused: Cas publish fail, server md5 may have changed.;';
+      mm(client.httpAgent, 'request', async () => {
+        throw casFailErr;
+      });
+      const success = await client.publishConfigCas('cas-data-id', 'cas-group', 'content-v2', 'stale-md5');
+      assert(success === false);
+    });
+
+    it('should rethrow non-conflict errors', async () => {
+      const otherErr: any = new Error('Nacos Server Error Status: 500');
+      otherErr.name = 'NacosServerResponseError';
+      mm(client.httpAgent, 'request', async () => {
+        throw otherErr;
+      });
+      await assert.rejects(
+        () => client.publishConfigCas('cas-data-id', 'cas-group', 'content-v2', 'md5-of-v1'),
+        /Status: 500/
+      );
     });
   });
 });


### PR DESCRIPTION
## Background

Fixes #110 — users asked for an MD5-guarded publish similar to a Redis optimistic lock:

```js
const content = await configClient.getConfig(dataId, group);
await configClient.publishConfigCas(dataId, group, newContent, casMd5); // fails if md5 mismatched
```

## Changes

Aligns with Java SDK `ConfigService#publishConfigCas`:

- `DataClient#publishConfigCas(dataId, group, content, casMd5, options?)` and `NacosConfigClient` wrapper (`src/client.ts`, `src/index.ts`)
  - gRPC transport: sets `ConfigPublishRequest.casMd5` (proto field already available); returns `false` when the server rejects (resultCode != 200)
  - HTTP transport: posts `casMd5` form param to the publish API; the server-side mismatch surfaces as a request error (consistent with existing error handling)
- `GrpcConfigProxy#publishSingle` gains an optional `casMd5` param
- `ClientWorker#publishSingle` / `#publishConfigCas` pass `casMd5` through publish options; omitted entirely when not provided (no behavior change for existing callers)
- `UnitOptions.unit` relaxed to optional (all its fields are optional in practice)
- README documents the new API with a usage example

## Tests

New pure unit test `packages/nacos-config/test/publish_config_cas.test.ts` (no live server needed, 8 cases):

```
npx midway-bin test --ts -- --file test/publish_config_cas.test.ts --timeout 30000
# 8 passing
```

Also verified: `pnpm -r run build` OK, existing `test/utils.test.ts` 9 passing, tslint reports no new issues on touched files.

Note: CI currently only runs `test/utils.test.ts` for nacos-config; maintainers may want to add this new test file to `.github/workflows/ci.yml`.

## Usage

```js
const crypto = require('crypto');
const current = await configClient.getConfig('app', 'DEFAULT_GROUP');
const casMd5 = crypto.createHash('md5').update(current || '').digest('hex');
const ok = await configClient.publishConfigCas('app', 'DEFAULT_GROUP', 'new=content', casMd5);
```